### PR TITLE
Ditch Vendor Config

### DIFF
--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -273,7 +273,7 @@ ui_print "- Copying files"
 cp -af $LIB $MODPATH/system/lib/soundfx/libv4a_fx_ics.so
 cp -af /system/etc/audio_effects.conf $MODPATH/system/etc/audio_effects.conf 2>/dev/null
 cp -af /system/etc/htc_audio_effects.conf $MODPATH/system/etc/htc_audio_effects.conf 2>/dev/null
-cp -af /system/vendor/etc/audio_effects.conf $MODPATH/system/vendor/etc/audio_effects.conf 2>/dev/null
+cp -af /system/etc/audio_effects.conf $MODPATH/system/vendor/etc/audio_effects.conf 2>/dev/null
 
 CONFIG_FILE=$MODPATH/system/etc/audio_effects.conf
 HTC_CONFIG_FILE=$MODPATH/system/etc/htc_audio_effects.conf


### PR DESCRIPTION
The vendor config doesn't work*, let's just use the regular one.

* https://forum.xda-developers.com/oneplus-3t/themes/v4a-fix-processing-using-magisk-t3572819